### PR TITLE
Make aiohttp.ClientSession optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,27 +35,35 @@ You can get an API key from
 
 # Usage
 
-`pyopenuv` starts within an
-[aiohttp](https://aiohttp.readthedocs.io/en/stable/) `ClientSession`:
-
 ```python
 import asyncio
-
-from aiohttp import ClientSession
 
 from pyopenuv import Client
 
 
 async def main() -> None:
-    """Create the aiohttp session and run the example."""
-    async with ClientSession() as websession:
-      # YOUR CODE HERE
+    """Rock and roll."""
+    client = pyopenuv.Client(
+      "<OPENUV.IO API KEY>",
+      "<LATITUDE>",
+      "<LONGITUDE>",
+      altitude="<ALTITUDE>")
+
+    # Get current UV index information:
+    await client.uv_index()
+
+    # Get forecasted UV information:
+    await client.uv_forecast()
+
+    # Get information on the window of time during which SPF protection
+    # should be used:
+    await client.uv_protection_window()
 
 
 asyncio.get_event_loop().run_until_complete(main())
 ```
 
-Create a client, initialize it, then get to it:
+If you have an existing `aiohttp.ClientSession`, you can use it:
 
 ```python
 import asyncio
@@ -66,24 +74,15 @@ from pyopenuv import Client
 
 
 async def main() -> None:
-    """Create the aiohttp session and run the example."""
-    async with ClientSession() as websession:
-      client = pyopenuv.Client(
-        "<OPENUV.IO API KEY>",
-        "<LATITUDE>",
-        "<LONGITUDE>",
-        websession,
-        altitude="<ALTITUDE>")
+    """Rock and roll."""
+    client = pyopenuv.Client(
+      "<OPENUV.IO API KEY>",
+      "<LATITUDE>",
+      "<LONGITUDE>",
+      altitude="<ALTITUDE>",
+      session=session)
 
-      # Get current UV index information:
-      await client.uv_index()
-
-      # Get forecasted UV information:
-      await client.uv_forecast()
-
-      # Get information on the window of time during which SPF protection
-      # should be used:
-      await client.uv_protection_window()
+      # ...
 
 
 asyncio.get_event_loop().run_until_complete(main())

--- a/example.py
+++ b/example.py
@@ -1,42 +1,30 @@
 """Run an example script to quickly test."""
 import asyncio
-
-from aiohttp import ClientSession
+import logging
 
 from pyopenuv import Client
 from pyopenuv.errors import OpenUvError
 
+_LOGGER = logging.getLogger()
+
 
 async def main() -> None:
     """Create the aiohttp session and run the example."""
-    async with ClientSession() as websession:
-        await run(websession)
+    logging.basicConfig(level=logging.INFO)
 
-
-async def run(websession: ClientSession):
-    """Run."""
     try:
         # Create a client:
-        client = Client(
-            '<API_KEY>',
-            39.7974509,
-            -104.8887227,
-            websession,
-            altitude=1609.3)
+        client = Client('<API_KEY>', 39.7974509, -104.8887227, altitude=1609.3)
 
         # Get current UV info:
-        print('CURRENT UV DATA:')
-        print(await client.uv_index())
+        _LOGGER.info('CURRENT UV DATA: %s', await client.uv_index())
 
         # Get forecasted UV info:
-        print()
-        print('FORECASTED UV DATA:')
-        print(await client.uv_forecast())
+        _LOGGER.info('FORECASTED UV DATA: %s', await client.uv_forecast())
 
         # Get UV protection window:
-        print()
-        print('UV PROTECTION WINDOW:')
-        print(await client.uv_protection_window())
+        _LOGGER.info(
+            'UV PROTECTION WINDOW: %s', await client.uv_protection_window())
     except OpenUvError as err:
         print(err)
 

--- a/pyopenuv/client.py
+++ b/pyopenuv/client.py
@@ -14,12 +14,12 @@ class Client:
             api_key: str,
             latitude: float,
             longitude: float,
-            websession: ClientSession,
             *,
-            altitude: float = 0.0) -> None:
+            altitude: float = 0.0,
+            session: ClientSession = None) -> None:
         """Initialize."""
         self._api_key = api_key
-        self._websession = websession
+        self._session = session or ClientSession()
         self.altitude = str(altitude)
         self.latitude = str(latitude)
         self.longitude = str(longitude)
@@ -46,8 +46,8 @@ class Client:
             'alt': self.altitude
         })
 
-        async with self._websession.request(method, url, headers=headers,
-                                            params=params) as resp:
+        async with self._session.request(method, url, headers=headers,
+                                         params=params) as resp:
             try:
                 resp.raise_for_status()
                 return await resp.json(content_type=None)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -13,107 +13,95 @@ from .fixtures.client import *  # noqa
 
 
 @pytest.mark.asyncio
-async def test_bad_api_key(aresponses, event_loop):
+async def test_bad_api_key(aresponses):
     """Test the that the property exception is raised with a bad API key."""
     aresponses.add(
         'api.openuv.io', '/api/v1/protection', 'get',
         aresponses.Response(text='', status=403))
 
     with pytest.raises(InvalidApiKeyError):
-        async with aiohttp.ClientSession(loop=event_loop) as websession:
-            client = Client(
-                TEST_API_KEY,
-                TEST_LATITUDE,
-                TEST_LONGITUDE,
-                websession,
-                altitude=TEST_ALTITUDE)
-            await client.uv_protection_window()
+        client = Client(
+            TEST_API_KEY,
+            TEST_LATITUDE,
+            TEST_LONGITUDE,
+            altitude=TEST_ALTITUDE)
+        await client.uv_protection_window()
 
 
 @pytest.mark.asyncio
-async def test_bad_request(aresponses, event_loop):
+async def test_bad_request(aresponses):
     """Test that the proper exception is raised during a bad request."""
     aresponses.add(
         'api.openuv.io', '/api/v1/bad_endpoint', 'get',
         aresponses.Response(text='', status=500))
 
     with pytest.raises(RequestError):
-        async with aiohttp.ClientSession(loop=event_loop) as websession:
-            client = Client(
-                TEST_API_KEY,
-                TEST_LATITUDE,
-                TEST_LONGITUDE,
-                websession,
-                altitude=TEST_ALTITUDE)
-            await client.request('get', 'bad_endpoint')
-
-
-@pytest.mark.asyncio
-async def test_create(event_loop):
-    """Test the creation of a client."""
-    async with aiohttp.ClientSession(loop=event_loop) as websession:
         client = Client(
             TEST_API_KEY,
             TEST_LATITUDE,
             TEST_LONGITUDE,
-            websession,
             altitude=TEST_ALTITUDE)
-        assert client.altitude == TEST_ALTITUDE
-        assert client.latitude == TEST_LATITUDE
-        assert client.longitude == TEST_LONGITUDE
+        await client.request('get', 'bad_endpoint')
 
 
 @pytest.mark.asyncio
-async def test_protection_window(
-        aresponses, event_loop, fixture_protection_window):
+async def test_create():
+    """Test the creation of a client."""
+    client = Client(
+        TEST_API_KEY, TEST_LATITUDE, TEST_LONGITUDE, altitude=TEST_ALTITUDE)
+
+    assert client.altitude == TEST_ALTITUDE
+    assert client.latitude == TEST_LATITUDE
+    assert client.longitude == TEST_LONGITUDE
+
+
+@pytest.mark.asyncio
+async def test_protection_window(aresponses, fixture_protection_window):
     """Test successfully retrieving the protection window."""
     aresponses.add(
         'api.openuv.io', '/api/v1/protection', 'get',
         aresponses.Response(
             text=json.dumps(fixture_protection_window), status=200))
 
-    async with aiohttp.ClientSession(loop=event_loop) as websession:
-        client = Client(
-            TEST_API_KEY,
-            TEST_LATITUDE,
-            TEST_LONGITUDE,
-            websession,
-            altitude=TEST_ALTITUDE)
-        data = await client.uv_protection_window()
-        assert data['result']['from_uv'] == 3.2509
+    client = Client(
+        TEST_API_KEY,
+        TEST_LATITUDE,
+        TEST_LONGITUDE,
+        altitude=TEST_ALTITUDE)
+
+    data = await client.uv_protection_window()
+    assert data['result']['from_uv'] == 3.2509
 
 
 @pytest.mark.asyncio
-async def test_uv_forecast(aresponses, event_loop, fixture_uv_forecast):
+async def test_uv_forecast(aresponses, fixture_uv_forecast):
     """Test successfully retrieving UV forecast info."""
     aresponses.add(
         'api.openuv.io', '/api/v1/forecast', 'get',
         aresponses.Response(text=json.dumps(fixture_uv_forecast), status=200))
 
-    async with aiohttp.ClientSession(loop=event_loop) as websession:
-        client = Client(
-            TEST_API_KEY,
-            TEST_LATITUDE,
-            TEST_LONGITUDE,
-            websession,
-            altitude=TEST_ALTITUDE)
-        data = await client.uv_forecast()
-        assert len(data['result']) == 2
+    client = Client(
+        TEST_API_KEY,
+        TEST_LATITUDE,
+        TEST_LONGITUDE,
+        altitude=TEST_ALTITUDE)
+
+    data = await client.uv_forecast()
+    assert len(data['result']) == 2
 
 
 @pytest.mark.asyncio
-async def test_uv_index(aresponses, event_loop, fixture_uv_index):
+async def test_uv_index(aresponses, fixture_uv_index):
     """Test successfully retrieving UV index info."""
     aresponses.add(
         'api.openuv.io', '/api/v1/uv', 'get',
         aresponses.Response(text=json.dumps(fixture_uv_index), status=200))
 
-    async with aiohttp.ClientSession(loop=event_loop) as websession:
-        client = Client(
-            TEST_API_KEY,
-            TEST_LATITUDE,
-            TEST_LONGITUDE,
-            websession,
-            altitude=TEST_ALTITUDE)
-        data = await client.uv_index()
-        assert data['result']['uv'] == 8.2342
+    client = Client(
+        TEST_API_KEY,
+        TEST_LATITUDE,
+        TEST_LONGITUDE,
+        altitude=TEST_ALTITUDE)
+
+    data = await client.uv_index()
+    assert data['result']['uv'] == 8.2342


### PR DESCRIPTION
**Describe what the PR does:**

This PR removes the requirement of passing an `aiohttp.ClientSession` into the Client; that is now optional.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests is written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
