### PR TITLE
Switch to f-strings (and remove support for Python 3.5.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,8 @@ pip install pyopenuv
 
 `pyopenuv` is currently supported on:
 
-* Python 3.5
 * Python 3.6
 * Python 3.7
-
-However, running the test suite currently requires Python 3.6 or higher; tests
-run on Python 3.5 will fail.
 
 # API Key
 

--- a/setup.py
+++ b/setup.py
@@ -14,17 +14,17 @@ from shutil import rmtree
 from setuptools import find_packages, setup, Command
 
 # Package meta-data.
-NAME = 'pyopenuv'
-DESCRIPTION = 'A simple Python API data from openuv.io'
-URL = 'https://github.com/bachya/pyopenuv'
-EMAIL = 'bachya1208@gmail.com'
-AUTHOR = 'Aaron Bach'
-REQUIRES_PYTHON = '>=3.5.3'
+NAME = "pyopenuv"
+DESCRIPTION = "A simple Python API data from openuv.io"
+URL = "https://github.com/bachya/pyopenuv"
+EMAIL = "bachya1208@gmail.com"
+AUTHOR = "Aaron Bach"
+REQUIRES_PYTHON = ">=3.6.0"
 VERSION = None
 
 # What packages are required for this module to be executed?
 REQUIRED = [  # type: ignore
-    'aiohttp'
+    "aiohttp"
 ]
 
 # The rest you shouldn't have to touch too much :)
@@ -37,28 +37,28 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 
 # Import the README and use it as the long-description.
 # Note: this will only work if 'README.md' is present in your MANIFEST.in file!
-with io.open(os.path.join(HERE, 'README.md'), encoding='utf-8') as f:
-    LONG_DESC = '\n' + f.read()
+with io.open(os.path.join(HERE, "README.md"), encoding="utf-8") as f:
+    LONG_DESC = "\n" + f.read()
 
 # Load the package's __version__.py module as a dictionary.
 ABOUT = {}  # type: ignore
 if not VERSION:
-    with open(os.path.join(HERE, NAME, '__version__.py')) as f:
+    with open(os.path.join(HERE, NAME, "__version__.py")) as f:
         exec(f.read(), ABOUT)  # pylint: disable=exec-used
 else:
-    ABOUT['__version__'] = VERSION
+    ABOUT["__version__"] = VERSION
 
 
 class UploadCommand(Command):
     """Support setup.py upload."""
 
-    description = 'Build and publish the package.'
+    description = "Build and publish the package."
     user_options = []  # type: ignore
 
     @staticmethod
     def status(string):
-        """Prints things in bold."""
-        print('\033[1m{0}\033[0m'.format(string))
+        """Print things in bold."""
+        print(f"\033[1m{string}\033[0m")
 
     def initialize_options(self):
         """Add options for initialization."""
@@ -71,21 +71,20 @@ class UploadCommand(Command):
     def run(self):
         """Run."""
         try:
-            self.status('Removing previous builds…')
-            rmtree(os.path.join(HERE, 'dist'))
+            self.status("Removing previous builds…")
+            rmtree(os.path.join(HERE, "dist"))
         except OSError:
             pass
 
-        self.status('Building Source and Wheel (universal) distribution…')
-        os.system('{0} setup.py sdist bdist_wheel --universal'.format(
-            sys.executable))
+        self.status("Building Source and Wheel (universal) distribution…")
+        os.system(f"{sys.executable} setup.py sdist bdist_wheel --universal")
 
-        self.status('Uploading the package to PyPi via Twine…')
-        os.system('twine upload dist/*')
+        self.status("Uploading the package to PyPi via Twine…")
+        os.system("twine upload dist/*")
 
-        self.status('Pushing git tags…')
-        os.system('git tag v{0}'.format(ABOUT['__version__']))
-        os.system('git push --tags')
+        self.status("Pushing git tags…")
+        os.system(f"git tag v{ABOUT['__version__']}")
+        os.system("git push --tags")
 
         sys.exit()
 
@@ -93,38 +92,34 @@ class UploadCommand(Command):
 # Where the magic happens:
 setup(
     name=NAME,
-    version=ABOUT['__version__'],
+    version=ABOUT["__version__"],
     description=DESCRIPTION,
     long_description=LONG_DESC,
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     author=AUTHOR,
     author_email=EMAIL,
     python_requires=REQUIRES_PYTHON,
     url=URL,
-    packages=find_packages(exclude=('tests',)),
+    packages=find_packages(exclude=("tests",)),
     # If your package is a single module, use this instead of 'packages':
     # py_modules=['mypackage'],
-
     # entry_points={
     #     'console_scripts': ['mycli=mymodule:cli'],
     # },
     install_requires=REQUIRED,
     include_package_data=True,
-    license='MIT',
+    license="MIT",
     classifiers=[
         # Trove classifiers
         # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Programming Language :: Python :: Implementation :: PyPy'
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Programming Language :: Python :: Implementation :: PyPy",
     ],
     # $ setup.py publish support.
-    cmdclass={
-        'upload': UploadCommand,
-    },
+    cmdclass={"upload": UploadCommand},
 )


### PR DESCRIPTION
**Describe what the PR does:**

This PR drops runtime support for Python 3.5.3 and makes the minimum runtime version 3.6. One of a few benefits to follow: we now get to use f-strings.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
