### PR TITLE
Move codecov CI action to v1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,7 @@ jobs:
           venv/bin/pip install -r requirements_test.txt
           venv/bin/py.test -s --verbose --cov-report term-missing --cov-report xml --cov=pyopenuv tests
 
-      - uses: codecov/codecov-action@v1.0.3
+      - uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
**Describe what the PR does:**

This PR generalizes the version of [`codecov-action`](https://github.com/codecov/codecov-action) used so that v1 patches are automatically included.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
