### PR TITLE
Adjust codespell to quiet level 4

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
       - id: codespell
         args:
           - --skip="./.*,*.json"
-          - --quiet-level=2
+          - --quiet-level=4
         exclude_types: [json]
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.7.9


### PR DESCRIPTION
**Describe what the PR does:**

This PR adjusts the "quiet level" for the codespell pre-commit hook to 4, which allows us to ignore warnings about automatic fixes that were disabled in the dictionary.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
