### PR TITLE
Handle asynctest not working in Python 3.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,15 +59,8 @@ repos:
     hooks:
       - id: pydocstyle
         files: ^((pyopenuv|tests)/.+)?[^/]+\.py$
-  - repo: https://github.com/ryanrhee/shellcheck-py
-    rev: v0.7.0.1-1
-    hooks:
-      - id: shellcheck
-        args:
-          - --format=json
-        files: script/*
-  - repo: https://github.com/ryanrhee/shellcheck-py
-    rev: v0.7.1.1
+  - repo: https://github.com/jumanjihouse/pre-commit-hooks
+    rev: 2.1.4
     hooks:
       - id: shellcheck
         args:

--- a/tests/async_mock.py
+++ b/tests/async_mock.py
@@ -1,0 +1,9 @@
+"""Define async mocking that works for various Python versions."""
+import sys
+
+if sys.version_info[:2] < (3, 8):
+    from asynctest.mock import *  # noqa
+
+    AsyncMock = CoroutineMock  # noqa: F405
+else:
+    from unittest.mock import *  # noqa

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,13 +3,13 @@
 import asyncio
 
 import aiohttp
-from asynctest import patch
 import pytest
 
 from pyopenuv import Client
 from pyopenuv.errors import InvalidApiKeyError, RequestError
 
-from .common import (
+from tests.async_mock import patch
+from tests.common import (
     TEST_ALTITUDE,
     TEST_API_KEY,
     TEST_LATITUDE,


### PR DESCRIPTION
**Describe what the PR does:**

This PR fixes the fact that `asynctest` no longer works in Python 3.8. The PR still ensures that it can be used for Python 3.6 and 3.7.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/pyopenuv/issues/39
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
