### PR TITLE
Implement retry logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,37 @@ async def main():
 asyncio.run(main())
 ```
 
+## Retries
+
+By default, `pyopenuv` will retry appropriate errors 3 times (with an interval of 3 seconds
+in-between). This logic can be changed by passing different values for `request_retries`
+and `request_retry_interval` to the `Client` constructor:
+
+```python
+import asyncio
+
+from pyopenuv import Client
+from pyopenuv.errors import OpenUvError
+
+
+async def main():
+    client = Client(
+        "<OPENUV_API_KEY>",
+        "<LATITUDE>",
+        "<LONGITUDE>",
+        altitude="<ALTITUDE>",
+        request_retries=5,
+        request_retry_interval=10,
+    )
+
+    # ...
+
+
+asyncio.run(main())
+```
+
+## Connection Pooling
+
 By default, the library creates a new connection to OpenUV with each coroutine. If you
 are calling a large number of coroutines (or merely want to squeeze out every second of
 runtime savings possible), an

--- a/pyopenuv/client.py
+++ b/pyopenuv/client.py
@@ -42,6 +42,7 @@ class Client:
         self.latitude = str(latitude)
         self.longitude = str(longitude)
 
+        # Implement a version of the request coroutine, but with backoff/retry logic:
         self.async_request = backoff.on_exception(
             backoff.constant,
             (asyncio.TimeoutError, ClientError),
@@ -85,7 +86,7 @@ class Client:
         return cast(Dict[str, Any], data)
 
     def _handle_on_giveup(self, _: Dict[str, Any]) -> None:
-        """Determine how to raise on giveup."""
+        """Determine what exception to raise upon giveup."""
         err_info = sys.exc_info()
         err = err_info[1].with_traceback(err_info[2])  # type: ignore
 
@@ -95,7 +96,7 @@ class Client:
 
     @staticmethod
     def _is_unauthorized_exception(err: BaseException) -> bool:
-        """Determine whether the retry sequence should give up."""
+        """Return whether an exception represents an unauthorized error."""
         return isinstance(err, ClientError) and any(
             code in str(err) for code in ("401", "403")
         )

--- a/pyopenuv/client.py
+++ b/pyopenuv/client.py
@@ -1,10 +1,12 @@
 """Define a client to interact with openuv.io."""
 import asyncio
 import logging
+import sys
 from typing import Any, Dict, Optional, cast
 
 from aiohttp import ClientSession, ClientTimeout
 from aiohttp.client_exceptions import ClientError
+import backoff
 
 from .errors import InvalidApiKeyError, RequestError
 
@@ -14,6 +16,8 @@ API_URL_SCAFFOLD = "https://api.openuv.io/api/v1"
 
 DEFAULT_PROTECTION_HIGH = 3.5
 DEFAULT_PROTECTION_LOW = 3.5
+DEFAULT_REQUEST_RETRIES = 3
+DEFAULT_REQUEST_RETRY_INTERVAL = 3
 DEFAULT_TIMEOUT = 30
 
 
@@ -28,6 +32,8 @@ class Client:
         *,
         altitude: float = 0.0,
         session: Optional[ClientSession] = None,
+        request_retries: int = DEFAULT_REQUEST_RETRIES,
+        request_retry_interval: int = DEFAULT_REQUEST_RETRY_INTERVAL,
     ) -> None:
         """Initialize."""
         self._api_key = api_key
@@ -36,7 +42,17 @@ class Client:
         self.latitude = str(latitude)
         self.longitude = str(longitude)
 
-    async def async_request(
+        self.async_request = backoff.on_exception(
+            backoff.constant,
+            (asyncio.TimeoutError, ClientError),
+            giveup=self._is_unauthorized_exception,
+            interval=request_retry_interval,
+            logger=_LOGGER,
+            max_tries=request_retries,
+            on_giveup=self._handle_on_giveup,
+        )(self._async_request)
+
+    async def _async_request(
         self, method: str, endpoint: str, **kwargs: Dict[str, str]
     ) -> Dict[str, Any]:
         """Make a request against OpenUV."""
@@ -57,36 +73,48 @@ class Client:
 
         assert session
 
-        try:
-            async with session.request(
-                method, f"{API_URL_SCAFFOLD}/{endpoint}", **kwargs
-            ) as resp:
-                resp.raise_for_status()
-                data = await resp.json()
-        except asyncio.TimeoutError:
-            raise RequestError("Request to endpoint timed out: {endpoint}") from None
-        except ClientError as err:
-            if any(code in str(err) for code in ("401", "403")):
-                raise InvalidApiKeyError("Invalid API key") from err
-            raise RequestError(f"Error requesting data from {endpoint}: {err}") from err
-        finally:
-            if not use_running_session:
-                await session.close()
+        async with session.request(
+            method, f"{API_URL_SCAFFOLD}/{endpoint}", **kwargs
+        ) as resp:
+            resp.raise_for_status()
+            data = await resp.json()
+
+        if not use_running_session:
+            await session.close()
 
         return cast(Dict[str, Any], data)
 
+    @staticmethod
+    def _is_unauthorized_exception(err: BaseException) -> bool:
+        """Determine whether the retry sequence should give up."""
+        return isinstance(err, ClientError) and any(
+            code in str(err) for code in ("401", "403")
+        )
+
+    def _handle_on_giveup(self, _: Dict[str, Any]) -> None:
+        """Determine how to raise on giveup."""
+        err_info = sys.exc_info()
+        err = err_info[1].with_traceback(err_info[2])  # type: ignore
+
+        if self._is_unauthorized_exception(err):
+            raise InvalidApiKeyError("Invalid API key") from err
+        raise RequestError(err) from err
+
     async def uv_forecast(self) -> Dict[str, Any]:
         """Get forecasted UV data."""
-        return await self.async_request("get", "forecast")
+        data = await self.async_request("get", "forecast")
+        return cast(Dict[str, Any], data)
 
     async def uv_index(self) -> Dict[str, Any]:
         """Get current UV data."""
-        return await self.async_request("get", "uv")
+        data = await self.async_request("get", "uv")
+        return cast(Dict[str, Any], data)
 
     async def uv_protection_window(
         self, low: float = DEFAULT_PROTECTION_LOW, high: float = DEFAULT_PROTECTION_HIGH
     ) -> Dict[str, Any]:
         """Get data on when a UV protection window is."""
-        return await self.async_request(
+        data = await self.async_request(
             "get", "protection", params={"from": str(low), "to": str(high)}
         )
+        return cast(Dict[str, Any], data)

--- a/pyopenuv/client.py
+++ b/pyopenuv/client.py
@@ -84,13 +84,6 @@ class Client:
 
         return cast(Dict[str, Any], data)
 
-    @staticmethod
-    def _is_unauthorized_exception(err: BaseException) -> bool:
-        """Determine whether the retry sequence should give up."""
-        return isinstance(err, ClientError) and any(
-            code in str(err) for code in ("401", "403")
-        )
-
     def _handle_on_giveup(self, _: Dict[str, Any]) -> None:
         """Determine how to raise on giveup."""
         err_info = sys.exc_info()
@@ -99,6 +92,13 @@ class Client:
         if self._is_unauthorized_exception(err):
             raise InvalidApiKeyError("Invalid API key") from err
         raise RequestError(err) from err
+
+    @staticmethod
+    def _is_unauthorized_exception(err: BaseException) -> bool:
+        """Determine whether the retry sequence should give up."""
+        return isinstance(err, ClientError) and any(
+            code in str(err) for code in ("401", "403")
+        )
 
     async def uv_forecast(self) -> Dict[str, Any]:
         """Get forecasted UV data."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,8 +59,9 @@ classifiers = [
 
 [tool.poetry.dependencies]
 aiohttp = "^3.7.4"
-python = "^3.6.0"
 asynctest = "^0.13.0"
+backoff = "^1.11.1"
+python = "^3.6.0"
 
 [tool.poetry.dev-dependencies]
 aresponses = "^2.0.0"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,6 +1,7 @@
 aiohttp>=3.7.4
 aresponses==2.0.0
 asynctest==0.13.0
+backoff==1.11.1
 pytest-aiohttp==0.3.0
 pytest-cov==2.8.1
 pytest==5.4.1

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -36,6 +36,9 @@ async def test_bad_api_key(aresponses):
                 TEST_LONGITUDE,
                 altitude=TEST_ALTITUDE,
                 session=session,
+                # Ensure the retry logic doesn't slow this test down:
+                request_retries=1,
+                request_retry_interval=0,
             )
             await client.uv_protection_window()
 
@@ -58,6 +61,9 @@ async def test_bad_request(aresponses):
                 TEST_LONGITUDE,
                 altitude=TEST_ALTITUDE,
                 session=session,
+                # Ensure the retry logic doesn't slow this test down:
+                request_retries=1,
+                request_retry_interval=0,
             )
             await client.async_request("get", "bad_endpoint")
 
@@ -98,6 +104,9 @@ async def test_timeout():
             TEST_LONGITUDE,
             altitude=TEST_ALTITUDE,
             session=session,
+            # Ensure the retry logic doesn't slow this test down:
+            request_retries=1,
+            request_retry_interval=0,
         )
 
         with patch("aiohttp.ClientSession.request", side_effect=asyncio.TimeoutError):


### PR DESCRIPTION
**Describe what the PR does:**

The OpenUV API can sometimes flake out, so this PR implements retry logic:

1. If an exception contains information related to an authorized API key, an `InvalidApiKeyError` is raised immediately.
2. Otherwise, the library will attempt again (using the parameters passed into the `Client` object).

**Does this fix a specific issue?**

Fixes https://github.com/bachya/pyopenuv/issues/48
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
