### PR TITLE
Switch backoff from constant to exponential

### DIFF
--- a/pyopenuv/client.py
+++ b/pyopenuv/client.py
@@ -16,8 +16,7 @@ API_URL_SCAFFOLD = "https://api.openuv.io/api/v1"
 
 DEFAULT_PROTECTION_HIGH = 3.5
 DEFAULT_PROTECTION_LOW = 3.5
-DEFAULT_REQUEST_RETRIES = 3
-DEFAULT_REQUEST_RETRY_INTERVAL = 3
+DEFAULT_REQUEST_RETRIES = 4
 DEFAULT_TIMEOUT = 30
 
 
@@ -33,7 +32,6 @@ class Client:
         altitude: float = 0.0,
         session: Optional[ClientSession] = None,
         request_retries: int = DEFAULT_REQUEST_RETRIES,
-        request_retry_interval: int = DEFAULT_REQUEST_RETRY_INTERVAL,
     ) -> None:
         """Initialize."""
         self._api_key = api_key
@@ -44,10 +42,9 @@ class Client:
 
         # Implement a version of the request coroutine, but with backoff/retry logic:
         self.async_request = backoff.on_exception(
-            backoff.constant,
+            backoff.expo,
             (asyncio.TimeoutError, ClientError),
             giveup=self._is_unauthorized_exception,
-            interval=request_retry_interval,
             logger=_LOGGER,
             max_tries=request_retries,
             on_giveup=self._handle_on_giveup,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -36,9 +36,7 @@ async def test_bad_api_key(aresponses):
                 TEST_LONGITUDE,
                 altitude=TEST_ALTITUDE,
                 session=session,
-                # Ensure the retry logic doesn't slow this test down:
                 request_retries=1,
-                request_retry_interval=0,
             )
             await client.uv_protection_window()
 
@@ -60,9 +58,7 @@ async def test_bad_request(aresponses):
                 TEST_LONGITUDE,
                 altitude=TEST_ALTITUDE,
                 session=session,
-                # Ensure the retry logic doesn't slow this test down:
                 request_retries=1,
-                request_retry_interval=0,
             )
             await client.async_request("get", "bad_endpoint")
 
@@ -120,8 +116,6 @@ async def test_request_retries(aresponses):
             TEST_LONGITUDE,
             altitude=TEST_ALTITUDE,
             session=session,
-            # Ensure the retry logic doesn't slow this test down:
-            request_retry_interval=0,
         )
         data = await client.uv_index()
         assert data["result"]["uv"] == 8.2342
@@ -154,9 +148,7 @@ async def test_timeout():
             TEST_LONGITUDE,
             altitude=TEST_ALTITUDE,
             session=session,
-            # Ensure the retry logic doesn't slow this test down:
             request_retries=1,
-            request_retry_interval=0,
         )
 
         with patch("aiohttp.ClientSession.request", side_effect=asyncio.TimeoutError):


### PR DESCRIPTION
**Describe what the PR does:**

This PR switches request backoff from a constant value to an exponential one; this will theoretically caused many retries to succeed more quickly.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
