### PR TITLE
Don't automatically give up on 403 errors

### DIFF
--- a/pyopenuv/client.py
+++ b/pyopenuv/client.py
@@ -44,7 +44,6 @@ class Client:
         self.async_request = backoff.on_exception(
             backoff.expo,
             (asyncio.TimeoutError, ClientError),
-            giveup=self._is_unauthorized_exception,
             logger=_LOGGER,
             max_tries=request_retries,
             on_giveup=self._handle_on_giveup,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -95,7 +95,9 @@ async def test_request_retries(aresponses):
         "/api/v1/uv",
         "get",
         aresponses.Response(
-            text="Not Found", status=404, headers={"Content-Type": "application/json"},
+            text="Not Found",
+            status=404,
+            headers={"Content-Type": "application/json"},
         ),
     )
     aresponses.add(


### PR DESCRIPTION
**Describe what the PR does:**

Our backoff/retry logic currently fails immediately when an HTTP `401` or `403` occurs. However, it appears that the OpenUV service can sporadically (and incorrectly) return a `403`, even when the API token is fine. So, this PR modifies things to ensure that we apply retry logic on _all_ errors, regardless of type.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
