### PR TITLE
Add ability for `Client` to automatically check API status

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ async def main():
     try:
         # Get the current status of the OpenUV API:
         print(await client.api_status())
-        # >>> {"status": true}
+        # >>> True
 
         # Get current UV info:
         print(await client.uv_index())
@@ -66,6 +66,39 @@ async def main():
         # Get UV protection window:
         print(await client.uv_protection_window())
         # >>> { "result": { ... } }
+    except OpenUvError as err:
+        print(f"There was an error: {err}")
+
+
+asyncio.run(main())
+```
+
+## Checking API Status Before Requests
+
+If you would prefer to not call `api_status` manually, you can configure the `Client` object
+to automatically check the status of the OpenUV API before executing any of the API
+methods—simply pass the `check_status_before_request` parameter:
+
+```python
+import asyncio
+
+from pyopenuv import Client
+from pyopenuv.errors import ApiUnavailableError, OpenUvError
+
+
+async def main():
+    client = Client(
+        "<OPENUV_API_KEY>",
+        "<LATITUDE>",
+        "<LONGITUDE>",
+        altitude="<ALTITUDE>",
+        check_status_before_request=True,
+    )
+
+    try:
+        print(await client.uv_index())
+    except ApiUnavailableError:
+        print("The API is unavailable")
     except OpenUvError as err:
         print(f"There was an error: {err}")
 

--- a/pyopenuv/errors.py
+++ b/pyopenuv/errors.py
@@ -7,6 +7,12 @@ class OpenUvError(Exception):
     pass
 
 
+class ApiUnavailableError(OpenUvError):
+    """Define an error related to the OpenUV API being down."""
+
+    pass
+
+
 class InvalidApiKeyError(OpenUvError):
     """Define an error related to invalid API keys."""
 


### PR DESCRIPTION
**Describe what the PR does:**

This PR allows the user to configure whether an API status check should automatically precede any other API request.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` with any new documentation.
