### PR TITLE
Add specific exception to detect API key rate limiting

### DIFF
--- a/pyopenuv/errors.py
+++ b/pyopenuv/errors.py
@@ -1,4 +1,6 @@
 """Define package errors."""
+from __future__ import annotations
+
 from typing import Any
 
 

--- a/pyopenuv/errors.py
+++ b/pyopenuv/errors.py
@@ -1,4 +1,5 @@
 """Define package errors."""
+from typing import Any
 
 
 class OpenUvError(Exception):
@@ -19,7 +20,44 @@ class InvalidApiKeyError(OpenUvError):
     pass
 
 
+class RateLimitExceededError(OpenUvError):
+    """Define an error related to exceeding the daily rate limit."""
+
+    pass
+
+
 class RequestError(OpenUvError):
     """Define an error related to invalid requests."""
 
     pass
+
+
+ERROR_MESSAGE_MAP = {
+    "User with API Key not found": InvalidApiKeyError,
+    "Daily API quota exceeded": RateLimitExceededError,
+}
+
+
+def raise_error(
+    endpoint: str, payload: dict[str, Any], raising_err: Exception | None
+) -> None:
+    """Raise the appropriate error based on the response data.
+
+    Args:
+        endpoint: The endpoint that was queried.
+        payload: An API response payload.
+        raising_err: The exception that caused the overall issue.
+
+    Raises:
+        exc: Raised upon an HTTP error.
+    """
+    if (error_msg := payload.get("error")) is None:
+        return
+
+    try:
+        exc = next(exc for idx, exc in ERROR_MESSAGE_MAP.items() if idx in error_msg)
+    except StopIteration:
+        exc = RequestError
+
+    exc.__cause__ = raising_err
+    raise exc(f"Error while querying {endpoint}: {error_msg}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,18 @@ def error_invalid_api_key_response_fixture() -> dict[str, Any]:
     )
 
 
+@pytest.fixture(name="error_rate_limit_response", scope="session")
+def error_rate_limit_response_fixture() -> dict[str, Any]:
+    """Define a fixture to return an rate limit error response.
+
+    Returns:
+        An API response payload.
+    """
+    return cast(
+        dict[str, Any], json.loads(load_fixture("error_rate_limit_response.json"))
+    )
+
+
 @pytest.fixture(name="protection_window_response", scope="session")
 def protection_window_response_fixture() -> dict[str, Any]:
     """Define a fixture to return a protection window response.

--- a/tests/fixtures/error_rate_limit_response.json
+++ b/tests/fixtures/error_rate_limit_response.json
@@ -1,0 +1,3 @@
+{
+  "error": "Daily API quota exceeded. Add billing details to get 15000 reqs/day or contact support@openuv.io to upgrade to Unlimited Plan."
+}


### PR DESCRIPTION
**Describe what the PR does:**

This PR adjusts the client to look at the response body for more specific error information—specifically, we can now detect a rate-limited API key.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
